### PR TITLE
Anbei meine Bearbeitung der Seite "urlaube.md"

### DIFF
--- a/docs/mitarbeiter/urlaube.md
+++ b/docs/mitarbeiter/urlaube.md
@@ -1,42 +1,42 @@
 # Urlaube 
 
-Als Mitarbeiter können Sie Urlaubsanträge stellen und einsehen. Wenn Sie sich im Kontext der Festanstellung 
-befinden, dann haben Sie direkt im Hauptmenü, den Punkt "Urlaube". Wenn Sie darauf klicken, dann sehen Sie 
-als allererstes eine Liste mit den anstehenden Feiertagen. Direkt darunter ist der Bereich für die Urlaube.
+Als Mitarbeiter können Sie Urlaubsanträge stellen und einsehen. Im Kontext der Festanstellung 
+befinden sich der Punkt "Urlaube" direkt im Hauptmenü. Wenn Sie darauf klicken sehen Sie als
+allererstes eine Liste mit den anstehenden Feiertagen, und direkt darunter ist der Bereich für die Urlaube.
 Das kann z.B. so aussehen:
 
 ![Urlaube](../img/context-employee/vacations-01-de.png)
 
-Die Kacheln zeigen die wichtigsten Urlaubs-KPIs an, für das ausgewählte Jahr. Direkt darunter ist die Liste
-mit den eingereichten Urlaubsanträgen. Hier sind die Informationen in den Kacheln erklärt, von links nach rechts:
+Die Kacheln zeigen die wichtigsten Urlaubs-KPIs für das ausgewählte Jahr an. Direkt darunter ist die Liste
+mit den eingereichten Urlaubsanträgen. Hier sind die Informationen in den Kacheln von links nach rechts erklärt:
 
-- **Urlaub anteilig**: Das ist der anteilige Urlaub, der Ihnen im ausgewählten Jahr zusteht.
-  Das ist abhängig von Ihrem Eintrittsdatum und der Anzahl der regulären Urlaubstage pro Jahr, die in Ihrem
+- **Urlaub anteilig**: Die erste Kachel zeigt den anteiligen Urlaub, der Ihnen im ausgewählten Jahr zusteht.
+  Dieser ist abhängig von Ihrem Eintrittsdatum und der Anzahl der regulären Urlaubstage pro Jahr, die in Ihrem
   Arbeitsvertrag vereinbart sind.
 - **Zusätzliche Urlaubstage**: Die zweite Kachel zeigt die Anzahl der zusätzlichen Urlaubstage an, die Sie
-  im ausgewählten Jahr erhalten. In dieser Kachel werden immer zwei Zahlen angezeigt. Die erste Zahl ist die
-  Anzahl der Urlaubstage, die aus dem letzten Jahr übertragen wurden. Viele Unternehmen erlauben es, dass
-  nicht genommene Urlaubstage in das nächste Jahr übertragen werden können. Diese zusätzlichen Urlaubstage
-  aus dem letzten Jahr haben dann oft ein Verfallsdatum. In den meisten Fällen müssen diese Urlaubstage
-  bis zum 31. März des Folgejahres genommen werden.<br/>
-  Die zweite Zahl in der Kachel zeigt die Anzahl von
-  gewährten Sonderurlaubstagen an. Für besondere Anlässe, wie z.B. Hochzeit, Umzug, Todesfall in der Familie, etc.,
-  kann Ihnen der Arbeitgeber Sonderurlaub gewähren. Sonderurlaub wird nicht vom bestehenden Urlaubskontingent abgezogen.
-- **Urlaubstage imsgesammt**: Die dritte Kachel zeigt die Anzahl der Urlaubstage an, die Sie im ausgewählten Jahr
+  im ausgewählten Jahr erhalten. In dieser Kachel werden immer zwei Zahlen angezeigt: Die erste Zahl ist die
+  Anzahl der Urlaubstage, die aus dem letzten Jahr übertragen wurden, da viele Unternehmen erlauben, dass
+  nicht genommene Urlaubstage in das nächste Jahr übernommen werden. Diese zusätzlichen Urlaubstage
+  aus dem letzten Jahr haben üblicherweise ein Verfallsdatum, das in den meisten Fällen der 31. März des Folgejahres
+  ist.<br/>
+  Die zweite Zahl in der Kachel zeigt die Anzahl von gewährten Sonderurlaubstagen an. Für besondere Anlässe, wie z.B.
+  Hochzeit, Umzug, Todesfall in der Familie etc., kann Ihnen der Arbeitgeber Sonderurlaub gewähren. Dieser wird
+  nicht vom bestehenden Urlaubskontingent abgezogen.
+- **Urlaubstage imsgesamt**: Die dritte Kachel zeigt die Anzahl der Urlaubstage an, die Sie im ausgewählten Jahr
   insgesamt zur Verfügung haben. Das ist die Summe aus dem anteiligen Urlaub und den zusätzlichen Urlaubstagen.
 - **Resturlaub**: Die vierte Kachel zeigt die Anzahl der Urlaubstage an, die Ihnen noch zur Verfügung stehen. Das ist
-  die Differenz aus de "Urlaubstage insgesamt" und den bereits eingereichten und genehmigten Urlaubstagen.
+  die Differenz aus "Urlaubstage insgesamt" und den bereits eingereichten und genehmigten Urlaubstagen.
 
 ## Urlaubsantrag stellen
 
-Um einen Urlaubsantrag zu stellen, klicken Sie auf den Button "Urlaub einreichen". Auf der nächsten Seite können Sie
-dann auswählen, ob Sie mehrere Tage, ein Tage oder einen halben Tag Urlaub beantragen wollen. Anschließend
-wählen Sie das Start- und Enddatum aus und geben optional eine Begründung ein. Mit dem Klick auf "Speichern"
-wird der Urlaubsantrag erstellt.
+Um einen Urlaubsantrag zu stellen, klicken Sie auf die Schaltfläche "Urlaub einreichen". Auf der nächsten Seite können
+Sie auswählen, ob Sie mehrere Tage, einen Tag oder einen halben Tag  beantragen wollen. Anschließend wählen Sie das 
+Start- und Enddatum aus und geben optional eine Begründung ein. Mit dem Klick auf "Speichern" wird der Urlaubsantrag
+erstellt.
 
 Standardmäßig müssen Urlaubsanträge von Ihrem Vorgesetzten genehmigt werden. Wenn das für Ihren Vertrag auch so
-konfiguriert ist, dann wird Ihr Vorgesetzter eine E-Mail-Benachrichtigung erhalten und kann den Urlaubsantrag
-dann kommentieren, genehmigen oder ablehnen. Sie werden dann per E-Mail benachrichtigt, sobald Ihr Vorgesetzter
+konfiguriert ist, wird Ihr Vorgesetzter eine E-Mail-Benachrichtigung erhalten und kann den Urlaubsantrag
+kommentieren, genehmigen oder ablehnen. Sie werden per E-Mail benachrichtigt, sobald Ihr Vorgesetzter
 den Urlaubsantrag bearbeitet hat.
 
 Wenn der Genehmigungsprozess für Urlaubsanträge in Ihrem Vertrag nicht aktiviert ist, dann wird jeder beantragte
@@ -46,33 +46,34 @@ Urlaub automatisch genehmigt.
 
 ### Wieso kann ich keinen halben Urlaubstag beantragen?
 
-Rein rechtlich gesehen gibt es in Deutschland keine halben Urlaubstage. Den das würde dem Ziel der Erholung
-entgegenstehen. Allerdings können Arbeitgeber und Arbeitnehmer, im Arbeitsvertrag vereinbaren, dass halbe Urlaubstage
-genommen werden können.
+In Deutschland gibt keinen Anspruch auf halbe Urlaubstage wenn es sich um den gesetzlichen Urlaubsanspruch handelt,
+da dies dem Ziel der Erholung entgegenstehen würde. Allerdings haben viele Arbeitnehmer mehr Urlaubstage als den
+gesetzlichen Anspruch über 20 Tage, und für diese vertraglichen Urlaubstage können Arbeitgeber und Arbeitnehmer im
+Arbeitsvertrag vereinbaren, dass halbe Urlaubstage genommen werden dürfen.
 
 Ob Ihnen diese Option in ZEIT.IO zur Verfügung steht, hängt von der Konfiguration Ihres Vertrags ab. Wenn Sie
-der Meinung sind dass Ihnen halbe Urlaubstage zustehen, dann wenden Sie sich bitte an Ihren Vorgesetzten oder
+der Meinung sind, dass Ihnen halbe Urlaubstage zustehen, dann wenden Sie sich bitte an Ihren Vorgesetzten oder
 an die Personalabteilung. Diese können die Option auf halbe Urlaubstage in Ihrem Vertrag aktivieren.
 
 ### Wie kann ich Sonderurlaub beantragen?
 
-Sie als Arbeitnehmer können keinen Sonderurlaub beantragen. Sonderurlaub wird vom Arbeitgeber gewährt und ist
-meistens an besondere Anlässe gebunden, wie z.B. Hochzeit, Umzug, Todesfall in der Familie, etc. Wenn Sie der
+Sie als Arbeitnehmer können keinen Sonderurlaub beantragen, denn dieser wird vom Arbeitgeber gewährt und ist
+an besondere Anlässe gebunden, wie z.B. Hochzeit, Umzug, Todesfall in der Familie etc. Wenn Sie der
 Meinung sind, dass Ihnen Sonderurlaub zusteht, dann wenden Sie sich bitte an Ihren Vorgesetzten oder an die
-Personalabteilung. Diese können dann prüfen, ob Ihnen Sonderurlaub gewährt werden kann und die entsprechenden
-Urlaubstage in ZEIT.IO eintragen.
+Personalabteilung. Diese können prüfen, ob Ihre Anfrage gewährt wird und die entsprechenden Urlaubstage in
+ZEIT.IO eintragen.
 
 ### Wieso verfallen nicht genommene Urlaubstage am Jahresende?
 
-Ob nicht genommene Urlaubstage am Jahresende verfallen oder nicht, hängt von der Konfiguration Ihres Arbeitsvertrags
-ab. Wenn Sie der Meinung sind dass Ihnen nicht genommene Urlaubstage aus dem letzten Jahr zustehen, dann wenden
-Sie sich bitte an Ihren Vorgesetzten oder an die Personalabteilung. Diese können dann prüfen, ob Ihnen die
-nicht genommenen Urlaubstage aus dem letzten Jahr in das neue Jahr übertragen werden können.
+Ob nicht genommene Urlaubstage am Jahresende verfallen oder nicht hängt von der Konfiguration Ihres Arbeitsvertrags
+ab. Wenn Sie der Meinung sind, dass Ihnen nicht genommene Urlaubstage aus dem letzten Jahr zustehen, dann wenden
+Sie sich bitte an Ihren Vorgesetzten oder an die Personalabteilung. Diese können prüfen, ob Ihnen die
+nicht genommenen Urlaubstage aus dem letzten Jahr in das neue Jahr übertragen werden.
 
 ### Wieso verfallen übertragene Urlaubstage aus dem letzten Jahr am 31. März?
 
-Nicht genommene Urlaubstage aus dem letzten Jahr, die in das neue Jahr übertragen wurden, verfallen standardmäßig
-am 31. März des neuen Jahres. Das ist die Standardkonfiguration in ZEIT.IO. Allerdings kann das Verfallsdatum
-für dise zusätzlichen Urlaubstage frei angepasst werden. Wenn Sie der Meinung sind, dass das Verfallsdatum für die
-übertragenen Urlaubstage angepasst werden sollte, dann wenden Sie sich bitte an Ihren Vorgesetzten oder an die
-Personalabteilung. Diese können dann das Verfallsdatum für die übertragenen Urlaubstage in ZEIT.IO anpassen.
+Nicht genommene Urlaubstage aus dem letzten Jahr, die in das neue Jahr übertragen wurden, verfallen am 31. März des
+neuen Jahres. Das ist die Standardkonfiguration in ZEIT.IO. Allerdings kann das Datum für diese zusätzlichen
+Urlaubstage frei angepasst werden. Wenn Sie der Meinung sind, dass das Ablaufdatum für die übertragenen Urlaubstage
+angepasst werden sollte, dann wenden Sie sich bitte an Ihren Vorgesetzten oder an die Personalabteilung. Diese können
+das Verfallsdatum für die übertragenen Urlaubstage in ZEIT.IO anpassen.


### PR DESCRIPTION
#Urlaube -> Satz vor und nach dem Screenshot angepasst **Urlaub anteilig** -> Satzumstellung
**Zusätzliche Urlaubstage** -> Satzänderung 1: „In dieser Kachel werden immer zwei Zahlen angezeigt: Die erste Zahl ist die Anzahl der Urlaubstage, die aus dem letzten Jahr übertragen wurden, da viele Unternehmen erlauben, dass nicht genommene Urlaubstage in das nächste Jahr übernommen werden. Diese zusätzlichen Urlaubstage aus dem letzten Jahr haben üblicherweise ein Verfallsdatum, das in den meisten Fällen der 31. März des Folgejahres ist.“ -> Satzänderung 2: Komma vor „etc.“ weg. -> Satzänderung 3: „Sonderurlaub“ im letzten Satz gegen „Dieser“ ausgetauscht. **Resturlaub** -> „de“ vor „Urlaubstage“ entfernt
#Urlaubsantrag stellen -> Korrektur: „Auf der nächsten Seite können Sie auswählen, ob Sie mehrere Tage, einen Tag oder einen halben Tag  beantragen wollen.“ -> außerdem mehrere „dann“ entfernt FAQs 
„halbe Tage“ -> Satzänderung: „In Deutschland gibt keinen Anspruch auf halbe Urlaubstage wenn es sich um den gesetzlichen Urlaubsanspruch handelt, da dies dem Ziel der Erholung entgegenstehen würde. Allerdings haben viele Arbeitnehmer mehr Urlaubstage als den gesetzlichen Anspruch über 20 Tage, und für diese vertraglichen Urlaubstage können Arbeitgeber und Arbeitnehmer im Arbeitsvertrag vereinbaren, dass halbe Urlaubstage genommen werden dürfen.“ „Sonderurlaub“ -> Satzänderung: „Sie als Arbeitnehmer können keinen Sonderurlaub beantragen, denn dieser wird vom Arbeitgeber gewährt und ist an besondere Anlässe gebunden, wie z.B. Hochzeit, Umzug, Todesfall in der Familie etc. Wenn Sie der Meinung sind, dass Ihnen Sonderurlaub zusteht, dann wenden Sie sich bitte an Ihren Vorgesetzten oder an die Personalabteilung. Diese können prüfen, ob Ihre Anfrage gewährt wird und die entsprechenden Urlaubstage in ZEIT.IO eintragen.“ -> ist immer an besondere Anlässe gebunden, nicht nur meistens, wurde gerichtlich geklärt. „nicht genommene Urlaubstage“ -> Komma entfernt; letzten Satz angepasst und „dann“ entfernt „übertragene Urlaubstage“ -> „standardmäßig“ entfernt, da im nächsten Satz auf den Standard verwiesen wird; 1 x „Verfallsdatum“ gegen „Datum“ ausgetauscht, „diese“ gegen „diese“, 1 x „Verfallsdatum“ gegen „Ablaufdatum“ ausgetauscht, „dann“ entfernt.