### PR TITLE
Update genehmigungsverfahren.md

### DIFF
--- a/docs/freiberufler/genehmigungsverfahren.md
+++ b/docs/freiberufler/genehmigungsverfahren.md
@@ -7,14 +7,13 @@ In ZEIT.IO gibt es einen Genehmigungsprozess für:
 - Zeiten, die Sie außerhalb von ZEIT.IO erfasst haben.
 - Ausgaben/Spesen.
 
-Das Genehmigungsverfahren ist ein wichtiger Bestandteil der Zusammenarbeit zwischen Freiberuflern und Organisationen.
-Der Genehmigungsprozess kann für jedes Mitglied im Projekt separat aktiviert werden.
+Das Genehmigungsverfahren ist ein wichtiger Bestandteil der Zusammenarbeit zwischen Freiberuflern und Organisationen,
+und kann für jedes Mitglied im Projekt separat aktiviert werden.
 
 Wenn das Genehmigungsverfahren für Ihre Projekt-Mitgliedschaft aktiviert ist, dann müssen Sie Ihre
-Zeiten und Ausgaben/Spesen erst genehmigen lassen, bevor sie in Rechnung gestellt werden können,
-bzw. bevor Sie dafür eine Gutschrift erhalten können.
-Dabei müssen Zeiten und Ausgaben immer getrennt eingereicht und genehmigt werden. Das ist so gemacht,
-weil es in großen Organisationen oft unterschiedliche Genehmiger für Zeiten und Ausgaben gibt.
+Zeiten und Ausgaben/Spesen erst genehmigen lassen, bevor sie in Rechnung gestellt werden, bzw. Sie dafür eine Gutschrift
+erhalten können. Dabei müssen Zeiten und Ausgaben immer getrennt eingereicht und genehmigt werden, weil es in großen
+Organisationen oft unterschiedliche Genehmiger für Zeiten und Ausgaben gibt.
 
 Wenn der Genehmigungsprozess für Ihre Projekt-Mitgliedschaft nicht aktiviert ist, dann sind alle
 Buchungen sofort genehmigt und können sofort in Rechnung gestellt werden.
@@ -23,7 +22,7 @@ Buchungen sofort genehmigt und können sofort in Rechnung gestellt werden.
     Das [Gutschriftverfahren](/freiberufler/gutschriftverfahren/) gibt es nur in Kombination mit dem Genehmigungsverfahren.
     Ohne Genehmigungsverfahren gibt es auch keine Gutschriften!
 
-In den folgenden Kapiteln wird beschrieben, wie Sie Genehmigung beantragen können:
+In den folgenden Kapiteln wird beschrieben, wie Sie eine Genehmigung beantragen können:
 
 - [Zeiten genehmigen lassen (TimeRecords)](/freiberufler/leistungsnachweise/#zeiten-genehmigen-lassen-timerecords)
 - [Externen Leistungsnachweis genehmigen lassen](/freiberufler/leistungsnachweise/#externen-leistungsnachweis-genehmigen-lassen)


### PR DESCRIPTION
# Genehmigungsverfahren 
3. Aufzählungspunkt: - Zeiten, die Sie außerhalb von ZEIT.IO erfasst und dann hochgeladen haben. -> "und dann hochgeladen" hinzugefügt

Das Genehmigungsverfahren ist ein wichtiger Bestandteil der Zusammenarbeit zwischen Freiberuflern und Organisationen, und kann für jedes Mitglied im Projekt separat aktiviert werden. -> Satz zusammengefügt

Wenn das Genehmigungsverfahren für Ihre Projekt-Mitgliedschaft aktiviert ist, dann müssen Sie Ihre Zeiten und Ausgaben/Spesen erst genehmigen lassen, bevor sie in Rechnung gestellt werden können, bzw. bevor Sie dafür eine Gutschrift erhalten können. Dabei müssen Zeiten und Ausgaben immer getrennt eingereicht und genehmigt werden. Das ist so gemacht, weil es in großen Organisationen oft unterschiedliche Genehmiger für Zeiten und Ausgaben gibt. -> Sätze gekürzt und zusammengefügt

Wenn der Genehmigungsprozess für Ihre Projekt-Mitgliedschaft nicht aktiviert ist, dann sind alle Buchungen sofort genehmigt und können sofort direkt in Rechnung gestellt werden. -> 1 x "sofort" gegen "direkt" ausgetauscht

In den folgenden Kapiteln wird beschrieben, wie Sie eine Genehmigung beantragen können -> "eine" hinzugefügt